### PR TITLE
Fix intros

### DIFF
--- a/data/missions/intro.txt
+++ b/data/missions/intro.txt
@@ -218,7 +218,7 @@ mission "Intro [3 Freighter]"
 
 
 
-mission "Intro [1 Interceptor]"
+#mission "Intro [1 Interceptor]"
   priority
   name "Escort convoy to <planet>"
   description "Escort a merchant convoy to <destination>, along with your new friend James."
@@ -262,7 +262,7 @@ mission "Intro [1 Interceptor]"
 
 
 
-mission "Intro [2 Interceptor]"
+#mission "Intro [2 Interceptor]"
   priority
   name "Delivery to <planet>"
   description "Deliver <commodity> to <destination>, while avoiding pirate attacks."
@@ -309,7 +309,7 @@ mission "Intro [2 Interceptor]"
 
 
 
-mission "Intro [3 Interceptor]"
+#mission "Intro [3 Interceptor]"
   priority
   name "Bring James to <planet>"
   description "Drop James off on <destination>, where he has a spot reserved in a retirement home."
@@ -354,7 +354,7 @@ mission "Intro [1 Transport]"
   passengers 5
   to offer
     has "Intro [0]: done"
-    has "ships: Transport"
+    has "ships: Interceptor"
     not "Intro [1 Freighter]: offered"
     not "Intro [1 Interceptor]: offered"
   

--- a/data/missions/intro.txt
+++ b/data/missions/intro.txt
@@ -23,7 +23,7 @@ mission "Intro [0]"
   destination "Rust"
   
   on offer
-    log "Finally scraped together enough money for a down payment on a starship. The interest on the mortgage is exorbitant."
+    log "Finally scraped together enough money for a down payment on a starship."
     log "Factions" "Deep" `The Deep is a region that developed in relative isolation from the rest of human space. Centuries ago it helped defeating the Alphas and bringing back peace to the rest of human space. Although formally part of the Republic, the Deep is autonomous, governing and policing its own systems. The Deep is one of the most technologically advanced and peaceful regions of human space; piracy has been eliminated, the independent justice system is very strong, and living standards are high. As a consequence, the Deep still views itself as a beacon of civilization.`
        `Deep legislation both restricts the sale of weapons produced outside the Deep, to ensure its laws and standards are observed throughout their space, and limits the export of Deep-produced weapons to other regions, on moral grounds.`
     log "Factions" "Free Worlds" `The Free Worlds is a confederacy of systems in the Rim, with its Senate based on Bourne, the human planet furthest away from Earth. They are still considered to be officially part of the Republic, although in practice the Free Worlds ignore Republic legislation and refuse to send representatives to Parliament on Earth.`
@@ -374,7 +374,7 @@ mission "Intro [1 Transport]"
     payment 40000
     conversation
       `Along the journey, you learned that the family you are transporting are named the Hendersons, and that they are moving to <planet> mostly because they hope the urban setting will be better for their kids than <origin>, where there were hardly any children at all and their village had only a few thousand people in it. The grandmother, Olivia, has also been chattering nonstop about how excited she is about being on a world where she can actually go sunbathing: "I've gotten much too old for snowshoeing," she says.`
-      `  You say goodbye to them and wish them well, and as agreed they pay you <payment>. You are already well on your way towards paying down your mortgage!`
+      `  You say goodbye to them and wish them well, and as agreed they pay you <payment>. You are already well on your way towards earning enough money for a bigger ship.`
       `  As James leaves the ship, he says, "Again, if you're okay with continuing to give me a ride, just meet me in the spaceport."`
       ``
       `  (As before, click the "Spaceport" button to continue this mission.)`


### PR DESCRIPTION
At the moment since ship catagories are automatically sorted by mass all player will get the interceptor intro mission. This makes little sense as there would be no reason for any captain to hire an unarmed shuttle as an escort. In adition to this there are refferences to going and "killing pirates" which also make no sense in the situation. 
I have also removed references to a mortage as the plaayer does not apear to have one in this version of the game so it is quite confusing to have it referenced and it has already been removed from the openning text. I have not removed the interceptor missions from the game files i only commented the first one out and enabled the transport ones so in the case that other changes mean that reverting is a good idea it will be easy. I have tested this pr and it works